### PR TITLE
Introduce the conditional compilation variable COLORSHADER_SUPPORTCOLORSPACE to remove the support for colour space when creating a colour shader

### DIFF
--- a/src/ShimSkiaSharp/SKShader.cs
+++ b/src/ShimSkiaSharp/SKShader.cs
@@ -2,9 +2,13 @@
 
 public abstract record SKShader
 {
+#if COLORSHADER_SUPPORTCOLORSPACE
     public static SKShader CreateColor(SKColor color, SKColorSpace colorSpace) 
         => new ColorShader(color, colorSpace);
-
+#else
+    public static SKShader CreateColor(SKColor color)
+        => new ColorShader(color);
+#endif
     public static SKShader CreateLinearGradient(SKPoint start, SKPoint end, SKColorF[] colors, SKColorSpace colorSpace, float[] colorPos, SKShaderTileMode mode) 
         => new LinearGradientShader(start, end, colors, colorSpace, colorPos, mode, null);
 
@@ -33,7 +37,11 @@ public abstract record SKShader
         => new TwoPointConicalGradientShader(start, startRadius, end, endRadius, colors, colorSpace, colorPos, mode, localMatrix);
 }
 
+#if COLORSHADER_SUPPORTCOLORSPACE
 public record ColorShader(SKColor Color, SKColorSpace ColorSpace) : SKShader;
+#else
+public record ColorShader(SKColor Color) : SKShader;
+#endif
 
 public record LinearGradientShader(SKPoint Start, SKPoint End, SKColorF[]? Colors, SKColorSpace ColorSpace, float[]? ColorPos, SKShaderTileMode Mode, SKMatrix? LocalMatrix) : SKShader;
 

--- a/src/Svg.CodeGen.Skia/SkiaCSharpModelExtensions.cs
+++ b/src/Svg.CodeGen.Skia/SkiaCSharpModelExtensions.cs
@@ -427,8 +427,10 @@ public static class SkiaCSharpModelExtensions
                 sb.Append($"{indent}var {counter.ShaderVarName}{counterShader} = ");
                 sb.AppendLine($"SKShader.CreateColor(");
                 sb.AppendLine($"{indent}    {colorShader.Color.ToSKColor()},");
+#if COLORSHADER_SUPPORTCOLORSPACE
                 sb.AppendLine($"{indent}    {(colorShader.ColorSpace == SKColorSpace.Srgb ? s_srgb : s_srgbLinear)});");
-                return;
+#endif
+                    return;
             }
             case LinearGradientShader linearGradientShader:
             {

--- a/src/Svg.Model/SvgExtensions.Painting.cs
+++ b/src/Svg.Model/SvgExtensions.Painting.cs
@@ -312,6 +312,7 @@ public static partial class SvgExtensions
         var skColors = colors.ToArray();
         float[] skColorPos = colorPos.ToArray();
 
+#if COLORSHADER_SUPPORTCOLORSPACE
         if (skColors.Length == 0)
         {
             return SKShader.CreateColor(new SKColor(0xFF, 0xFF, 0xFF, 0x00), skColorSpace);
@@ -320,6 +321,16 @@ public static partial class SvgExtensions
         {
             return SKShader.CreateColor(skColors[0], skColorSpace);
         }
+#else
+        if (skColors.Length == 0)
+        {
+            return SKShader.CreateColor(new SKColor(0xFF, 0xFF, 0xFF, 0x00));
+        }
+        else if (skColors.Length == 1)
+        {
+            return SKShader.CreateColor(skColors[0]);
+        }
+#endif
 
         if (svgGradientUnits == SvgCoordinateUnits.ObjectBoundingBox)
         {
@@ -486,6 +497,7 @@ public static partial class SvgExtensions
         var skColors = colors.ToArray();
         float[] skColorPos = colorPos.ToArray();
 
+#if COLORSHADER_SUPPORTCOLORSPACE
         if (skColors.Length == 0)
         {
             return SKShader.CreateColor(new SKColor(0xFF, 0xFF, 0xFF, 0x00), skColorSpace);
@@ -501,6 +513,21 @@ public static partial class SvgExtensions
                 skColors.Length > 0 ? skColors[skColors.Length - 1] : new SKColor(0x00, 0x00, 0x00, 0xFF), 
                 skColorSpace);
         }
+#else
+        if (skColors.Length == 0)
+        {
+            return SKShader.CreateColor(new SKColor(0xFF, 0xFF, 0xFF, 0x00));
+        }
+        else if (skColors.Length == 1)
+        {
+            return SKShader.CreateColor(skColors[0]);
+        }
+
+        if (radius == 0.0)
+        {
+            return SKShader.CreateColor(skColors.Length > 0 ? skColors[skColors.Length - 1] : new SKColor(0x00, 0x00, 0x00, 0xFF));
+        }
+#endif
 
         var isRadialGradient = skCenter.X == skFocal.X && skCenter.Y == skFocal.Y;
         
@@ -812,7 +839,11 @@ public static partial class SvgExtensions
 #else
                     var skColorSpace = isLinearRgb ? SKColorSpace.SrgbLinear : SKColorSpace.Srgb;
 #endif
+#if COLORSHADER_SUPPORTCOLORSPACE
                     var skColorShader = SKShader.CreateColor(skColor, skColorSpace);
+#else
+                    var skColorShader = SKShader.CreateColor(skColor);
+#endif
                     if (skColorShader is { })
                     {
                         skPaint.Shader = skColorShader;
@@ -842,7 +873,11 @@ public static partial class SvgExtensions
                         if (fallbackServer is SvgColourServer svgColourServerFallback)
                         {
                             var skColor = GetColor(svgColourServerFallback, opacity, ignoreAttributes);
+#if COLORSHADER_SUPPORTCOLORSPACE
                             var skColorShader = SKShader.CreateColor(skColor, skColorSpace);
+#else
+                            var skColorShader = SKShader.CreateColor(skColor);
+#endif
                             if (skColorShader is { })
                             {
                                 skPaint.Shader = skColorShader;
@@ -873,7 +908,11 @@ public static partial class SvgExtensions
                         if (fallbackServer is SvgColourServer svgColourServerFallback)
                         {
                             var skColor = GetColor(svgColourServerFallback, opacity, ignoreAttributes);
+#if COLORSHADER_SUPPORTCOLORSPACE
                             var skColorShader = SKShader.CreateColor(skColor, skColorSpace);
+#else
+                            var skColorShader = SKShader.CreateColor(skColor);
+#endif
                             if (skColorShader is { })
                             {
                                 skPaint.Shader = skColorShader;
@@ -918,7 +957,11 @@ public static partial class SvgExtensions
                         if (fallbackServer is SvgColourServer svgColourServerFallback)
                         {
                             var skColor = GetColor(svgColourServerFallback, opacity, ignoreAttributes);
+#if COLORSHADER_SUPPORTCOLORSPACE
                             var skColorShader = SKShader.CreateColor(skColor, skColorSpace);
+#else
+                            var skColorShader = SKShader.CreateColor(skColor);
+#endif
                             if (skColorShader is { })
                             {
                                 skPaint.Shader = skColorShader;

--- a/src/Svg.Skia/SkiaModel.cs
+++ b/src/Svg.Skia/SkiaModel.cs
@@ -253,11 +253,15 @@ public class SkiaModel
         {
             case ColorShader colorShader:
             {
+#if COLORSHADER_SUPPORTCOLORSPACE
                 return SkiaSharp.SKShader.CreateColor(
                     ToSKColor(colorShader.Color),
                     colorShader.ColorSpace == SKColorSpace.Srgb 
                         ? Settings.Srgb 
                         : Settings.SrgbLinear);
+#else
+                return SkiaSharp.SKShader.CreateColor(ToSKColor(colorShader.Color));
+#endif
             }
             case LinearGradientShader linearGradientShader:
             {


### PR DESCRIPTION
Because the shader with the colour space parameter causes performance and compatibility problems with the output pdf, the pre-compilation parameter COLORSHADER_SUPPORTCOLORSPACE was introduced to disregard the colour space parameter when creating the colour shader.