### PR TITLE
Fix error in generated code

### DIFF
--- a/src/Svg.CodeGen.Skia/SkiaCSharpModelExtensions.cs
+++ b/src/Svg.CodeGen.Skia/SkiaCSharpModelExtensions.cs
@@ -426,9 +426,11 @@ public static class SkiaCSharpModelExtensions
             {
                 sb.Append($"{indent}var {counter.ShaderVarName}{counterShader} = ");
                 sb.AppendLine($"SKShader.CreateColor(");
-                sb.AppendLine($"{indent}    {colorShader.Color.ToSKColor()},");
 #if COLORSHADER_SUPPORTCOLORSPACE
+                sb.AppendLine($"{indent}    {colorShader.Color.ToSKColor()},");
                 sb.AppendLine($"{indent}    {(colorShader.ColorSpace == SKColorSpace.Srgb ? s_srgb : s_srgbLinear)});");
+#else
+                sb.AppendLine($"{indent}    {colorShader.Color.ToSKColor()});");
 #endif
                     return;
             }


### PR DESCRIPTION
Fix the build error in the generated code, otherwise VS reports a build error when build the whole solution.

The `dotnet build` command is still reporting the same issue though, which I have not found the root cause yet.