### PR TITLE
Should also set SKPaint.Color value when server is a solid color.

### DIFF
--- a/src/Svg.Model/SvgExtensions.Painting.cs
+++ b/src/Svg.Model/SvgExtensions.Painting.cs
@@ -844,6 +844,7 @@ public static partial class SvgExtensions
 #else
                     var skColorShader = SKShader.CreateColor(skColor);
 #endif
+                    skPaint.Color = skColor;
                     if (skColorShader is { })
                     {
                         skPaint.Shader = skColorShader;


### PR DESCRIPTION
Set `skPaint.Color` when filled with a solid colour to address the issue that SKSvgCanvas doesn't support colour shaders.