### PR TITLE
No longer set a default clip for SVG <image> elements (#111175)

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.100",
+    "version": "8.0.100",
     "rollForward": "latestMinor",
     "allowPrerelease": true
   }

--- a/src/Svg.Model/Drawables/Elements/ImageDrawable.cs
+++ b/src/Svg.Model/Drawables/Elements/ImageDrawable.cs
@@ -81,7 +81,6 @@ public sealed class ImageDrawable : DrawableBase
 
         var destClip = SKRect.Create(location.X, location.Y, width, height);
         drawable.DestRect = SvgExtensions.CalculateRect(svgImage.AspectRatio, drawable.SrcRect, destClip);
-        drawable.Clip = destClip;
 
         var skClipRect = SvgExtensions.GetClipRect(svgImage.Clip, destClip);
         if (skClipRect is { })


### PR DESCRIPTION
If a clip is set for an <image> in SVG, when exporting the SVG to PDF at a very small scale, the image may be clipped and not appear in the PDF—this could be a bug or intended behavior in Skia.

To minimize this issue, if no explicit clip is set for the image, we no longer apply a default clip.

Note: If an explicit clip is present, the image may still be omitted during small-scale PDF export.
